### PR TITLE
Fix xml node leaks in client

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -94,6 +94,7 @@ function saveAttachments()
         end
     end
     xmlSaveFile(xml)
+    xmlUnloadFile(xml)
     outputChatBox("Attachment setup saved.")
 end
 
@@ -104,7 +105,11 @@ function loadAttachments()
     end
     local xml = xmlLoadFile(xmlFile)
     local veh = getPedOccupiedVehicle(localPlayer)
-    if not veh then outputChatBox("You must be in a vehicle.") return end
+    if not veh then
+        outputChatBox("You must be in a vehicle.")
+        xmlUnloadFile(xml)
+        return
+    end
 
     for _, node in ipairs(xmlNodeGetChildren(xml)) do
         local id = tonumber(xmlNodeGetAttribute(node, "id"))


### PR DESCRIPTION
## Summary
- close xml file after saving attachments
- ensure xml file is closed if loading fails due to not being in a vehicle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853594aab1c832fb43ee37a25d9372a