### PR TITLE
Add server-side loading of saved attachments

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -187,22 +187,22 @@ function loadAttachments()
         return
     end
 
+    local attachments = {}
     for _, node in ipairs(xmlNodeGetChildren(xml)) do
-        local id = tonumber(xmlNodeGetAttribute(node, "id"))
-        local x = tonumber(xmlNodeGetAttribute(node, "x"))
-        local y = tonumber(xmlNodeGetAttribute(node, "y"))
-        local z = tonumber(xmlNodeGetAttribute(node, "z"))
-        local rx = tonumber(xmlNodeGetAttribute(node, "rx"))
-        local ry = tonumber(xmlNodeGetAttribute(node, "ry"))
-        local rz = tonumber(xmlNodeGetAttribute(node, "rz"))
-        local sx = tonumber(xmlNodeGetAttribute(node, "sx")) or 1
-        local sy = tonumber(xmlNodeGetAttribute(node, "sy")) or sx
-        local sz = tonumber(xmlNodeGetAttribute(node, "sz")) or sx
-        local obj = createObject(id, 0, 0, 0)
-        attachElements(obj, veh, x, y, z, rx, ry, rz)
-        setObjectScale(obj, sx, sy, sz)
-        table.insert(attachedObjects, obj)
+        table.insert(attachments, {
+            id = tonumber(xmlNodeGetAttribute(node, "id")),
+            x = tonumber(xmlNodeGetAttribute(node, "x")),
+            y = tonumber(xmlNodeGetAttribute(node, "y")),
+            z = tonumber(xmlNodeGetAttribute(node, "z")),
+            rx = tonumber(xmlNodeGetAttribute(node, "rx")),
+            ry = tonumber(xmlNodeGetAttribute(node, "ry")),
+            rz = tonumber(xmlNodeGetAttribute(node, "rz")),
+            sx = tonumber(xmlNodeGetAttribute(node, "sx")) or 1,
+            sy = tonumber(xmlNodeGetAttribute(node, "sy")),
+            sz = tonumber(xmlNodeGetAttribute(node, "sz")),
+        })
     end
     xmlUnloadFile(xml)
+    triggerServerEvent("loadVehicleAttachments", resourceRoot, veh, attachments)
     outputChatBox("Attachments loaded.")
 end

--- a/server.lua
+++ b/server.lua
@@ -17,6 +17,38 @@ addEventHandler("attachObjectToVehicle", resourceRoot, function(veh, modelID, ox
     triggerClientEvent(client, "onObjectAttached", resourceRoot, obj)
 end)
 
+-- Create multiple attachments from client provided data
+addEvent("loadVehicleAttachments", true)
+addEventHandler("loadVehicleAttachments", resourceRoot, function(veh, attachments)
+    if not isElement(veh) or type(attachments) ~= "table" then
+        return
+    end
+
+    for _, data in ipairs(attachments) do
+        local modelID = tonumber(data.id)
+        if modelID and engineGetModelNameFromID(modelID) then
+            local x = tonumber(data.x) or 0
+            local y = tonumber(data.y) or 0
+            local z = tonumber(data.z) or 0
+            local rx = tonumber(data.rx) or 0
+            local ry = tonumber(data.ry) or 0
+            local rz = tonumber(data.rz) or 0
+            local sx = tonumber(data.sx) or 1
+            local sy = tonumber(data.sy) or sx
+            local sz = tonumber(data.sz) or sx
+
+            local obj = createObject(modelID, 0, 0, 0)
+            attachElements(obj, veh, x, y, z, rx, ry, rz)
+            setObjectScale(obj, sx, sy, sz)
+
+            vehicleAttachments[veh] = vehicleAttachments[veh] or {}
+            table.insert(vehicleAttachments[veh], obj)
+
+            triggerClientEvent(client, "onObjectAttached", resourceRoot, obj)
+        end
+    end
+end)
+
 local function cleanupVehicleAttachments(veh)
     if vehicleAttachments[veh] then
         for _, obj in ipairs(vehicleAttachments[veh]) do


### PR DESCRIPTION
## Summary
- add a new server event `loadVehicleAttachments` that rebuilds attachments on the server
- send attachment table to the server from `loadAttachments()` instead of creating them client side

## Testing
- `luac -v` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685374a7d114832f8487487079de0e0a