### PR TITLE
Fix attachments table population

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -211,6 +211,18 @@ function loadAttachments()
         attachElements(obj, veh, x, y, z, rx, ry, rz)
         setObjectScale(obj, sx, sy, sz)
         table.insert(attachedObjects, obj)
+        table.insert(attachments, {
+            id = id,
+            x = x,
+            y = y,
+            z = z,
+            rx = rx,
+            ry = ry,
+            rz = rz,
+            sx = sx,
+            sy = sy,
+            sz = sz
+        })
     end
     xmlUnloadFile(xml)
     triggerServerEvent("loadVehicleAttachments", resourceRoot, veh, attachments)


### PR DESCRIPTION
## Summary
- populate attachments table when loading saved attachments

## Testing
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685376fd70ec832f9232e970ecc66ad6